### PR TITLE
Fix erase for flash blocks with addresses exceeding 16 bits

### DIFF
--- a/bootloader/flash/flash.c
+++ b/bootloader/flash/flash.c
@@ -49,7 +49,7 @@ void read_flash(uint24_t address, uint8_t *buf, size_t count) {
 
 static inline void flash_erase_blk(size_t blk_idx)
 {
-    uint24_t blk_addr = blk_idx * FLASH_BLOCK_SIZ;
+    uint24_t blk_addr = (uint24_t)blk_idx * FLASH_BLOCK_SIZ;
     TBLPTRU = (uint8_t)(blk_addr >> 16);
     TBLPTRH = (uint8_t)(blk_addr >> 8);
     TBLPTRL = (uint8_t)(blk_addr & 0xff);

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -274,8 +274,9 @@ void main(void) {
     enum flashing_status status;
 
     mcu_init();
-    uart_init();
+    uart_init(RX_STATE_DISABLED);
 
+    uart_rx_enable();
     ret = uart_expect_msg(HOST_HANDSHAKE_MSG, 5, 60000);
     if (ret) {
         /* nothing interesting from PC, booting old code */
@@ -288,10 +289,13 @@ void main(void) {
         }
     }
 
+
+    uart_rx_disable();
     erase_flash(BTLD_OFFSET);
 
     uart_send_buf((uint8_t *)MCU_HANDSHAKE_RESP, strlen(MCU_HANDSHAKE_RESP));
 
+    uart_rx_enable();
     status = fw_receive();
     if (status != STATUS_NO_ERR) {
         uart_write_byte(mcu_errs[status]);

--- a/bootloader/uart/uart.h
+++ b/bootloader/uart/uart.h
@@ -1,8 +1,25 @@
 #include <stdbool.h>
 
-void uart_init(void);
+#include <xc.h>
+
+enum rx_state {
+    RX_STATE_DISABLED,
+    RX_STATE_ENABLED,
+};
+
+void uart_init(enum rx_state rx_state);
 int uart_get_byte(uint8_t *byte, size_t timeout_us, bool block);
 void uart_write_byte(uint8_t byte);
 int uart_expect_msg(char *msg, size_t len, size_t timeout_us);
 void uart_send_buf(uint8_t *buf, size_t cnt);
+
+static inline void uart_rx_disable(void)
+{
+    RCSTA1bits.CREN = 0;
+}
+
+static inline void uart_rx_enable(void)
+{
+    RCSTA1bits.CREN = 1;
+}
 


### PR DESCRIPTION
To compute the address corresponding to the offset of the erase size block we must cast the block index to address type uint24_t to avoid the truncation of the result to our machine's default int type size(16 bits)